### PR TITLE
Ensuring correct spacing between list items

### DIFF
--- a/VUMIFPSbakalaurinis.cls
+++ b/VUMIFPSbakalaurinis.cls
@@ -317,3 +317,7 @@
 % Tarpai tarp išnašų eilučių nustatomi į 1.5 eilutės
 \let\oldfootnote\footnote
 \renewcommand{\footnote}[1]{\oldfootnote{\onehalfspacing #1}}
+
+% Panaikinami dvigubi tarpai tarp sąrašo elementų
+\RequirePackage{enumitem}
+\setlist{nosep}


### PR DESCRIPTION
Currently, the spacing between list items is too big (looks like double line spacing).

This pull request reduces the spacing between "itemize" and "enumerate" items to match that of a document.

Before:
![image](https://user-images.githubusercontent.com/29043447/116919328-c90be980-ac59-11eb-96b1-7356c487f111.png)

After:
![image](https://user-images.githubusercontent.com/29043447/116919368-d9bc5f80-ac59-11eb-8fad-ebde9a72242c.png)
